### PR TITLE
Retrieve Name servers displayed on multiple lines

### DIFF
--- a/extra.go
+++ b/extra.go
@@ -36,7 +36,7 @@ func parser(re *regexp.Regexp, group int, data string) (result []string) {
 //Parse uniq name servers from whois
 func ParseNameServers(whois string) []string {
 	
-	resultNameServers := parser(regexp.MustCompile(`(?i)Name Server:\s+(.*?)(\s|$)`), 1, whois)
+	resultNameServers := parser(regexp.MustCompile(`(?i)^N(?:.*)Server:\s+(.*?)(?:\s|$)`), 1, whois)
 
 	if len(resultNameServers) == 0 {
 		var re = regexp.MustCompile(`(?i)(Name servers:\n(?:\s+(?:[a-zA-Z-_\.0-9]+)\n)+)`)


### PR DESCRIPTION
## Issue I had
When doing `whois` commands, I had some cases where the name servers were displayed on multiple lines. 
So I had either : 
```
Domain Name: DOMAIN.TLD
Tech Email: email@domain.tld
Name Server: NS1.DOMAIN.TLD
Name Server: NS2.DOMAIN.TLD
DNSSEC: unsigned

```
or : 
```
Domain: domain.tld
Script: LATIN

Registrant:
        NOT DISCLOSED!
        Visit www.domain.tls for webbased WHOIS.

On-site(s):
        NOT DISCLOSED!
        Visit www.domain.tls for webbased WHOIS.

Registrar:
        Name: domain.tld, LLC
        Website: http://www.domain.tld

Name servers:
        ns2.dns.domain.tld
        ns1.dns.domain.tld

```

The last way to display name servers did not handle by `golang-whois`. So, I decided to implement it. 

## Proposed implementation
I choose to retrieve all the name servers with a regex. Then, the first line, which is `Name Servers :`, is skipped. The other lines are name servers and returned as a slice of string.

```golang
//Parse uniq name servers from whois
func ParseNameServers(whois string) []string {

	resultNameServers := parser(regexp.MustCompile(`(?i)Name Server:\s+(.*?)(\s|$)`), 1, whois)

	if len(resultNameServers) == 0 {
		var re = regexp.MustCompile(`(?i)(Name servers:\n(?:\s+(?:[a-zA-Z-_\.0-9]+)\n)+)`)
		nameServersString := re.FindString(whois)

		scanner := bufio.NewScanner(strings.NewReader(nameServersString))
		// Read first line, ie. Name Servers:
		scanner.Scan()

		// Iterate over Name Servers
		for scanner.Scan() {
			resultNameServers = append(resultNameServers, strings.TrimSpace(scanner.Text()))
		}

	}

	return resultNameServers
}
```

## Code to test
I used the following code to validate that my code does not insert any regression.
Link : [https://goplay.space/#nWDdBdgvBf1](https://goplay.space/#nWDdBdgvBf1)

```golang
package main

import (
	"bufio"
	"fmt"
	"regexp"
	"strings"
)

func main() {
	var nameServer = `
Domain Name: DOMAIN.TLD
Tech Email: email@domain.tld
Name Server: NS1.DOMAIN.TLD
Name Server: NS2.DOMAIN.TLD
DNSSEC: unsigned

	`
	var nameServers = `
Domain: domain.tld
Script: LATIN

Registrant:
        NOT DISCLOSED!
        Visit www.domain.tls for webbased WHOIS.

On-site(s):
        NOT DISCLOSED!
        Visit www.domain.tls for webbased WHOIS.

Registrar:
        Name: domain.tld, LLC
        Website: http://www.domain.tld

Name servers:
        ns2.dns.domain.tld
        ns1.dns.domain.tld


	`

	fmt.Printf("Name Server :\n%v\n", ParseNameServers(nameServer))
	fmt.Printf("Name Servers :\n%v\n", ParseNameServers(nameServers))

}

//Parse uniq name servers from whois
func ParseNameServers(whois string) []string {

	resultNameServers := parser(regexp.MustCompile(`(?i)Name Server:\s+(.*?)(\s|$)`), 1, whois)

	if len(resultNameServers) == 0 {
		var re = regexp.MustCompile(`(?i)(Name servers:\n(?:\s+(?:[a-zA-Z-_\.0-9]+)\n)+)`)
		nameServersString := re.FindString(whois)

		scanner := bufio.NewScanner(strings.NewReader(nameServersString))
		// Read first line, ie. Name Servers:
		scanner.Scan()

		// Iterate over Name Servers
		for scanner.Scan() {
			resultNameServers = append(resultNameServers, strings.TrimSpace(scanner.Text()))
		}

	}

	return resultNameServers
}

func parser(re *regexp.Regexp, group int, data string) (result []string) {

	found := re.FindAllStringSubmatch(data, -1)

	if len(found) > 0 {
		for _, one := range found {
			if len(one) >= 2 && len(one[group]) > 0 {

				result = appendIfMissing(result, one[group])

			}
		}
	}

	return
}

func appendIfMissing(slice []string, i string) []string {

	i = strings.ToLower(i)

	for _, ele := range slice {
		if ele == i {
			return slice
		}
	}

	return append(slice, i)

}
```
